### PR TITLE
Set minimum version for flask

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 click
-flask
+flask>=2.0.0
 Flask-Caching
 GDAL
 large-image

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
     python_requires=">=3.6",
     install_requires=[
         "click",
-        "flask",
+        "flask>=2.0.0",
         "Flask-Caching",
         "furl",
         "GDAL",


### PR DESCRIPTION
The `download_name` argument I am using is only compatible with flask>=2.0.0

https://flask.palletsprojects.com/en/2.0.x/changes/#version-2-0-0

Resolve #17 