### PR TITLE
Add bound tile layer override

### DIFF
--- a/localtileserver/widgets.py
+++ b/localtileserver/widgets.py
@@ -67,6 +67,7 @@ def get_leaflet_tile_layer(
     # Safely import ipyleaflet
     try:
         from ipyleaflet import TileLayer
+        from traitlets import Tuple
     except ImportError as e:
         raise ImportError(f"Please install `ipyleaflet`: {e}")
 

--- a/localtileserver/widgets.py
+++ b/localtileserver/widgets.py
@@ -69,6 +69,11 @@ def get_leaflet_tile_layer(
         from ipyleaflet import TileLayer
     except ImportError as e:
         raise ImportError(f"Please install `ipyleaflet`: {e}")
+
+    class BoundTileLayer(TileLayer):
+        # https://github.com/jupyter-widgets/ipyleaflet/issues/888
+        bounds = Tuple(default_value=None, allow_none=True).tag(sync=True, o=True)
+
     source, created = get_or_create_tile_client(source, port=port, debug=debug)
     url = source.get_tile_url(
         projection=projection,
@@ -80,7 +85,7 @@ def get_leaflet_tile_layer(
     )
     if attribution is None:
         attribution = DEFAULT_ATTRIBUTION
-    tile_layer = TileLayer(url=url, attribution=attribution, **kwargs)
+    tile_layer = BoundTileLayer(url=url, attribution=attribution, **kwargs)
     if created:
         # HACK: Prevent the client from being garbage collected
         tile_layer.tile_server = source


### PR DESCRIPTION
Overrides `ipyleaflet.TileLayer` to constrain the region of requested tiles, per https://github.com/jupyter-widgets/ipyleaflet/issues/888

This significantly reduces the load on the tile server

Once this feature is released, I will take out this override and set a minimum version for ipyleaflet in the extra dependencies