### PR TITLE
Add Cesium split view

### DIFF
--- a/localtileserver/tileserver/templates/tileserver/base.html
+++ b/localtileserver/tileserver/templates/tileserver/base.html
@@ -101,6 +101,9 @@
             <a class="nav-link" href="{{ url_for('tileserver.examples')}}">Examples</a>
           </li>
           <li class="nav-item active">
+            <a class="nav-link" href="{{ url_for('tileserver.split-form')}}">Compare</a>
+          </li>
+          <li class="nav-item active">
             <a class="nav-link" href="{{ url_for('tileserver.doc')}}" target="_blank">Swagger</a>
           </li>
         </ul>

--- a/localtileserver/tileserver/templates/tileserver/cesiumSplitViewer.html
+++ b/localtileserver/tileserver/templates/tileserver/cesiumSplitViewer.html
@@ -1,0 +1,130 @@
+{% extends "tileserver/base.html" %}
+
+{% block content %}
+
+{% include 'tileserver/_include/cesium.html' %}
+
+<div class="slidecontainer" id="opacityTool">
+  <label for="rasterOpacityRange">Raster Layers Opacity: </label>
+  <input type="range" min="1" max="100" value="100" class="overlay" id="rasterOpacityRange" onChange="updateTilesOpacity(event, value)" onInput="updateTilesOpacity(event, value)" style="top: 5px; left: 5px;">
+</div>
+
+<style>
+  #slider {
+    position: absolute;
+    left: 50%;
+    top: 0px;
+    background-color: #d3d3d3;
+    width: 5px;
+    height: 100%;
+    z-index: 99999;
+  }
+
+  #slider:hover {
+    cursor: ew-resize;
+  }
+</style>
+
+<script>
+  // Set up Cesium split view
+  // https://sandcastle.cesium.com/?src=Imagery%20Layers%20Split.html
+  var cesiumContainer = document.getElementById('cesiumContainer');
+  var slider = document.createElement('div');
+  slider.className = 'slider';
+  slider.id = 'slider';
+  cesiumContainer.appendChild(slider)
+
+  viewer.scene.imagerySplitPosition =
+    slider.offsetLeft / slider.parentElement.offsetWidth;
+  var handler = new Cesium.ScreenSpaceEventHandler(slider);
+  var moveActive = false;
+
+  function move(movement) {
+    if (!moveActive) {
+      return;
+    }
+
+    var relativeOffset = movement.endPosition.x;
+    var splitPosition =
+      (slider.offsetLeft + relativeOffset) /
+      slider.parentElement.offsetWidth;
+    slider.style.left = 100.0 * splitPosition + "%";
+    viewer.scene.imagerySplitPosition = splitPosition;
+  }
+
+  handler.setInputAction(function() {
+    moveActive = true;
+  }, Cesium.ScreenSpaceEventType.LEFT_DOWN);
+  handler.setInputAction(function() {
+    moveActive = true;
+  }, Cesium.ScreenSpaceEventType.PINCH_START);
+
+  handler.setInputAction(move, Cesium.ScreenSpaceEventType.MOUSE_MOVE);
+  handler.setInputAction(move, Cesium.ScreenSpaceEventType.PINCH_MOVE);
+
+  handler.setInputAction(function() {
+    moveActive = false;
+  }, Cesium.ScreenSpaceEventType.LEFT_UP);
+  handler.setInputAction(function() {
+    moveActive = false;
+  }, Cesium.ScreenSpaceEventType.PINCH_END);
+
+  // Add tile layers to scene
+  var params = new URLSearchParams(window.location.search);
+  var filenameA = params.get('filenameA');
+  var filenameB = params.get('filenameB');
+
+  var tileProvider;
+  var tileLayerA;
+  var tileLayerB;
+  var layers = viewer.scene.imageryLayers;
+
+  var tileUrlA = `${host}/tiles/{z}/{x}/{y}.png?projection=EPSG:3857&filename=${filenameA}`;
+  var tileUrlB = `${host}/tiles/{z}/{x}/{y}.png?projection=EPSG:3857&filename=${filenameB}`;
+
+  fetch(`${host}/metadata?filename=${filenameA}`)
+    .then(response => response.json())
+    .then(data => {
+      var extents = data["bounds"];
+      var rectangle = Cesium.Rectangle.fromDegrees(extents.xmin, extents.ymin, extents.xmax, extents.ymax)
+
+      var tileProvider = new Cesium.UrlTemplateImageryProvider({
+        url: tileUrlA,
+        subdomains: null,
+        rectangle: rectangle,
+      });
+      tileLayerA = layers.addImageryProvider(tileProvider);
+      tileLayerA.splitDirection = Cesium.ImagerySplitDirection.LEFT;
+
+      viewer.camera.flyTo({
+        destination: rectangle,
+      });
+    });
+
+  fetch(`${host}/metadata?filename=${filenameB}`)
+    .then(response => response.json())
+    .then(data => {
+      var extents = data["bounds"];
+      var rectangle = Cesium.Rectangle.fromDegrees(extents.xmin, extents.ymin, extents.xmax, extents.ymax)
+
+      var tileProvider = new Cesium.UrlTemplateImageryProvider({
+        url: tileUrlB,
+        subdomains: null,
+        rectangle: rectangle,
+      });
+      tileLayerB = layers.addImageryProvider(tileProvider);
+      tileLayerB.splitDirection = Cesium.ImagerySplitDirection.RIGHT;
+
+      viewer.camera.flyTo({
+        destination: rectangle,
+      });
+    });
+
+  function updateTilesOpacity(e, value) {
+    value = Number(value) / 100.0;
+    tileLayerA.alpha = value;
+    tileLayerB.alpha = value;
+  }
+</script>
+
+{% endblock %}

--- a/localtileserver/tileserver/templates/tileserver/splitForm.html
+++ b/localtileserver/tileserver/templates/tileserver/splitForm.html
@@ -1,0 +1,19 @@
+{% extends "tileserver/base.html" %}
+
+{% block content %}
+
+<section>
+  <center>
+    <h1>Comparison</h1>
+    <p>Enter the two files you would like to compare</p>
+    <form action="/split/" method="GET">
+      <input name="filenameA" />
+      <br />
+      <input name="filenameB" />
+      <br />
+      <input type="submit" />
+    </form>
+  </center>
+</section>
+
+{% endblock %}

--- a/localtileserver/tileserver/urls.py
+++ b/localtileserver/tileserver/urls.py
@@ -6,6 +6,7 @@ tileserver.add_url_rule("/", view_func=views.CesiumViewer.as_view("index"))
 tileserver.add_url_rule("/roi/", view_func=views.GeoJSViewer.as_view("roi"))
 tileserver.add_url_rule("/examples", view_func=views.ExampleChoices.as_view("examples"))
 tileserver.add_url_rule("/split/", view_func=views.CesiumSplitViewer.as_view("split"))
+tileserver.add_url_rule("/split/form/", view_func=views.SplitViewForm.as_view("split-form"))
 
 # REST endpoints
 rest.api.add_resource(

--- a/localtileserver/tileserver/urls.py
+++ b/localtileserver/tileserver/urls.py
@@ -5,6 +5,7 @@ from localtileserver.tileserver.blueprint import tileserver
 tileserver.add_url_rule("/", view_func=views.CesiumViewer.as_view("index"))
 tileserver.add_url_rule("/roi/", view_func=views.GeoJSViewer.as_view("roi"))
 tileserver.add_url_rule("/examples", view_func=views.ExampleChoices.as_view("examples"))
+tileserver.add_url_rule("/split/", view_func=views.CesiumSplitViewer.as_view("split"))
 
 # REST endpoints
 rest.api.add_resource(

--- a/localtileserver/tileserver/utilities.py
+++ b/localtileserver/tileserver/utilities.py
@@ -175,19 +175,22 @@ def get_clean_filename(filename: str):
     return filename
 
 
-def get_clean_filename_from_request():
+def get_clean_filename_from_request(param_name: str = "filename", strict: bool = False):
     try:
         # First look for filename in URL params
-        f = request.args.get("filename")
+        f = request.args.get(param_name)
         if not f:
             raise KeyError
         filename = get_clean_filename(f)
     except KeyError:
         # Backup to app.config
         try:
-            filename = get_clean_filename(current_app.config["filename"])
+            filename = get_clean_filename(current_app.config[param_name])
         except KeyError:
+            message = "No filename set in app config or URL params. Using sample data."
+            if strict:
+                raise OSError(message)
             # Fallback to sample data
-            logger.error("No filename set in app config or URL params. Using sample data.")
+            logger.error(message)
             filename = get_data_path("landsat.tif")
     return filename

--- a/localtileserver/tileserver/views.py
+++ b/localtileserver/tileserver/views.py
@@ -39,6 +39,23 @@ class ExampleChoices(View):
         return render_template("tileserver/exampleChoices.html")
 
 
+class CesiumSplitViewer(View):
+    def dispatch_request(self):
+        try:
+            filename = utilities.get_clean_filename_from_request("filenameA", strict=True)
+            _ = utilities.get_tile_source(filename)
+        except (OSError, AttributeError, TileSourceFileNotFoundError):
+            f = request.args.get("filenameA")
+            return render_template("tileserver/404file.html", filename=f), 404
+        try:
+            filename = utilities.get_clean_filename_from_request("filenameB", strict=True)
+            _ = utilities.get_tile_source(filename)
+        except (OSError, AttributeError, TileSourceFileNotFoundError):
+            f = request.args.get("filenameB")
+            return render_template("tileserver/404file.html", filename=f), 404
+        return render_template("tileserver/cesiumSplitViewer.html")
+
+
 @tileserver.context_processor
 def raster_context():
     try:

--- a/localtileserver/tileserver/views.py
+++ b/localtileserver/tileserver/views.py
@@ -56,6 +56,11 @@ class CesiumSplitViewer(View):
         return render_template("tileserver/cesiumSplitViewer.html")
 
 
+class SplitViewForm(View):
+    def dispatch_request(self):
+        return render_template("tileserver/splitForm.html")
+
+
 @tileserver.context_processor
 def raster_context():
     try:


### PR DESCRIPTION
This adds a new Cesium split view for comparing two different raster files - note that this does not currently let users select bands/colormaps and they must compare two separate files
<img width="1385" alt="Screen Shot 2021-12-31 at 5 15 32 PM" src="https://user-images.githubusercontent.com/22067021/147840097-6bee2a6c-c488-4711-8860-61bbdf3adeee.png">

I'll see if I can make time to implement this so that a user can select bands for each file but that might get a bit complex

