### PR TITLE
Implement discrete palettes

### DIFF
--- a/localtileserver/client.py
+++ b/localtileserver/client.py
@@ -55,6 +55,7 @@ class BaseTileClient:
         vmax: Union[Union[float, int], List[Union[float, int]]] = None,
         nodata: Union[Union[float, int], List[Union[float, int]]] = None,
         scheme: Union[str, List[str]] = None,
+        n_colors: int = 255,
         grid: bool = False,
     ):
         """Get slippy maps tile URL (e.g., `/zoom/x/y.png`).
@@ -87,6 +88,9 @@ class BaseTileClient:
             with the range of the data mapped into the specified number of
             colors (e.g., a palette with two colors will split exactly halfway
             between the min and max values).
+        n_colors : int
+            The number (positive integer) of colors to discretize the matplotlib
+            color palettes when used.
         grid : bool
             Show the outline of each tile. This is useful when debugging your
             tile viewer.
@@ -112,6 +116,8 @@ class BaseTileClient:
             params["grid"] = True
         if scheme is not None:
             params["scheme"] = scheme
+        if n_colors:
+            params["n_colors"] = n_colors
         return add_query_parameters(self.create_url("api/tiles/{z}/{x}/{y}.png"), params)
 
     def extract_roi(
@@ -173,6 +179,7 @@ class BaseTileClient:
         vmax: Union[Union[float, int], List[Union[float, int]]] = None,
         nodata: Union[Union[float, int], List[Union[float, int]]] = None,
         scheme: Union[str, List[str]] = None,
+        n_colors: int = 255,
         output_path: pathlib.Path = None,
     ):
         params = {}
@@ -190,6 +197,8 @@ class BaseTileClient:
             params["nodata"] = nodata
         if scheme is not None:
             params["scheme"] = scheme
+        if n_colors:
+            params["n_colors"] = n_colors
         url = add_query_parameters(self.create_url("api/thumbnail"), params)
         r = requests.get(url)
         r.raise_for_status()

--- a/localtileserver/client.py
+++ b/localtileserver/client.py
@@ -54,6 +54,7 @@ class BaseTileClient:
         vmin: Union[Union[float, int], List[Union[float, int]]] = None,
         vmax: Union[Union[float, int], List[Union[float, int]]] = None,
         nodata: Union[Union[float, int], List[Union[float, int]]] = None,
+        scheme: Union[str, List[str]] = None,
         grid: bool = False,
     ):
         """Get slippy maps tile URL (e.g., `/zoom/x/y.png`).
@@ -79,6 +80,13 @@ class BaseTileClient:
             a single band.
         nodata : float
             The value from the band to use to interpret as not valid data.
+        scheme : str
+            This is either ``linear`` (the default) or ``discrete``. If a
+            palette is specified, ``linear`` uses a piecewise linear
+            interpolation, and ``discrete`` uses exact colors from the palette
+            with the range of the data mapped into the specified number of
+            colors (e.g., a palette with two colors will split exactly halfway
+            between the min and max values).
         grid : bool
             Show the outline of each tile. This is useful when debugging your
             tile viewer.
@@ -102,6 +110,8 @@ class BaseTileClient:
             params["projection"] = projection
         if grid:
             params["grid"] = True
+        if scheme is not None:
+            params["scheme"] = scheme
         return add_query_parameters(self.create_url("api/tiles/{z}/{x}/{y}.png"), params)
 
     def extract_roi(
@@ -162,6 +172,7 @@ class BaseTileClient:
         vmin: Union[Union[float, int], List[Union[float, int]]] = None,
         vmax: Union[Union[float, int], List[Union[float, int]]] = None,
         nodata: Union[Union[float, int], List[Union[float, int]]] = None,
+        scheme: Union[str, List[str]] = None,
         output_path: pathlib.Path = None,
     ):
         params = {}
@@ -177,6 +188,8 @@ class BaseTileClient:
             params["max"] = vmax
         if nodata is not None:
             params["nodata"] = nodata
+        if scheme is not None:
+            params["scheme"] = scheme
         url = add_query_parameters(self.create_url("api/thumbnail"), params)
         r = requests.get(url)
         r.raise_for_status()

--- a/localtileserver/tileserver/palettes.py
+++ b/localtileserver/tileserver/palettes.py
@@ -80,13 +80,15 @@ def mpl_to_palette(cmap: str, n_colors: int = 255):
     return color_list
 
 
-def get_palette_by_name(name: str):
+def get_palette_by_name(name: str, n_colors: int = 255):
     """Get a palette by name.
 
     This supports matplotlib colormaps and palettable palettes.
 
     If the palette is a valid palettable name, return that name. Otherwise,
     this will generate a full palette from the given name.
+
+    ``n_colors`` is only used if fetching a Matplotlib colormap.
     """
     palette_valid_or_raise(name)
     if is_palettable_palette(name):
@@ -94,7 +96,7 @@ def get_palette_by_name(name: str):
     if name in SIMPLE_PALETTES:
         return SIMPLE_PALETTES[name]
     if is_mpl_cmap(name):
-        return mpl_to_palette(name)
+        return mpl_to_palette(name, n_colors=n_colors)
 
 
 def get_palettes():

--- a/localtileserver/tileserver/rest.py
+++ b/localtileserver/tileserver/rest.py
@@ -145,16 +145,9 @@ class BaseImageView(View):
         palette = style_args.get("palette", None)
         scheme = style_args.get("scheme", None)
         nodata = style_args.get("nodata", None)
-        import logging
-
-        logger = logging.getLogger(__name__)
-        logger.error(f"->>>>>>>>>> {scheme}")
-        logger.error(f"->>>>>>>>>> {request.args}")
         sty = style.make_style(
             band, vmin=vmin, vmax=vmax, palette=palette, nodata=nodata, scheme=scheme
         )
-        logger.error(f"->>>>>>>>>> {sty}")
-        logger.error(f"->>>>>>>>>> {style_args}")
         return utilities.get_tile_source(filename, projection, encoding=encoding, style=sty)
 
 

--- a/localtileserver/tileserver/rest.py
+++ b/localtileserver/tileserver/rest.py
@@ -152,7 +152,10 @@ class BaseImageView(View):
         palette = style_args.get("palette", None)
         scheme = style_args.get("scheme", None)
         nodata = style_args.get("nodata", None)
-        n_colors = int(style_args.get("n_colors", 255))
+        if style_args.get("n_colors", ""):
+            n_colors = int(style_args.get("n_colors"))
+        else:
+            n_colors = 255
         sty = style.make_style(
             band,
             vmin=vmin,

--- a/localtileserver/tileserver/rest.py
+++ b/localtileserver/tileserver/rest.py
@@ -50,6 +50,12 @@ STYLE_PARAMS = {
         "in": "query",
         "type": "str",
     },
+    "scheme": {
+        "description": "This is either ``linear`` (the default) or ``discrete``. If a palette is specified, ``linear`` uses a piecewise linear interpolation, and ``discrete`` uses exact colors from the palette with the range of the data mapped into the specified number of colors (e.g., a palette with two colors will split exactly halfway between the min and max values).",
+        "in": "query",
+        "type": "str",
+        "default": "linear",
+    },
     "min": {
         "description": "The minimum value for the color mapping.",
         "in": "query",
@@ -137,8 +143,18 @@ class BaseImageView(View):
         vmin = style_args.get("min", None)
         vmax = style_args.get("max", None)
         palette = style_args.get("palette", None)
+        scheme = style_args.get("scheme", None)
         nodata = style_args.get("nodata", None)
-        sty = style.make_style(band, vmin=vmin, vmax=vmax, palette=palette, nodata=nodata)
+        import logging
+
+        logger = logging.getLogger(__name__)
+        logger.error(f"->>>>>>>>>> {scheme}")
+        logger.error(f"->>>>>>>>>> {request.args}")
+        sty = style.make_style(
+            band, vmin=vmin, vmax=vmax, palette=palette, nodata=nodata, scheme=scheme
+        )
+        logger.error(f"->>>>>>>>>> {sty}")
+        logger.error(f"->>>>>>>>>> {style_args}")
         return utilities.get_tile_source(filename, projection, encoding=encoding, style=sty)
 
 

--- a/localtileserver/tileserver/rest.py
+++ b/localtileserver/tileserver/rest.py
@@ -56,6 +56,13 @@ STYLE_PARAMS = {
         "type": "str",
         "default": "linear",
     },
+    "n_colors": {
+        "description": "The number (positive integer) of colors to discretize the matplotlib color palettes when used.",
+        "in": "query",
+        "type": "int",
+        "example": 24,
+        "default": 255,
+    },
     "min": {
         "description": "The minimum value for the color mapping.",
         "in": "query",
@@ -145,8 +152,15 @@ class BaseImageView(View):
         palette = style_args.get("palette", None)
         scheme = style_args.get("scheme", None)
         nodata = style_args.get("nodata", None)
+        n_colors = int(style_args.get("n_colors", 255))
         sty = style.make_style(
-            band, vmin=vmin, vmax=vmax, palette=palette, nodata=nodata, scheme=scheme
+            band,
+            vmin=vmin,
+            vmax=vmax,
+            palette=palette,
+            nodata=nodata,
+            scheme=scheme,
+            n_colors=n_colors,
         )
         return utilities.get_tile_source(filename, projection, encoding=encoding, style=sty)
 

--- a/localtileserver/tileserver/style.py
+++ b/localtileserver/tileserver/style.py
@@ -29,6 +29,7 @@ def make_single_band_style(
     vmax: Union[int, float] = None,
     palette: Union[str, List[str]] = None,
     nodata: Union[int, float] = None,
+    scheme: str = None,
 ):
     style = None
     if isinstance(band, (int, str)):
@@ -53,6 +54,8 @@ def make_single_band_style(
             else:
                 # TODO: check contents to make sure its a list of valid HEX colors
                 style["palette"] = palette
+        if scheme is not None:
+            style["scheme"] = scheme
     return style
 
 
@@ -71,6 +74,7 @@ def make_style(
     vmin: Union[Union[float, int], List[Union[float, int]]] = None,
     vmax: Union[Union[float, int], List[Union[float, int]]] = None,
     nodata: Union[Union[float, int], List[Union[float, int]]] = None,
+    scheme: Union[str, List[str]] = None,
 ):
     style = None
     # Handle when user sets min/max/etc. but forgot band. Default to 1
@@ -81,7 +85,9 @@ def make_style(
 
     if isinstance(band, (int, str)):
         # Handle viewing single band
-        style = make_single_band_style(band, vmin, vmax, palette, nodata)
+        style = make_single_band_style(
+            band, vmin=vmin, vmax=vmax, palette=palette, nodata=nodata, scheme=scheme
+        )
     elif isinstance(band, Iterable):
         # Handle viewing multiple bands together
         style = {"bands": []}
@@ -94,7 +100,7 @@ def make_style(
             p = safe_get(palette, i)
             nod = safe_get(nodata, i)
             style["bands"].append(
-                make_single_band_style(b, vmin=vmi, vmax=vma, palette=p, nodata=nod),
+                make_single_band_style(b, vmin=vmi, vmax=vma, palette=p, nodata=nod, scheme=scheme),
             )
     # Return JSON encoded
     if style:

--- a/localtileserver/tileserver/style.py
+++ b/localtileserver/tileserver/style.py
@@ -30,6 +30,7 @@ def make_single_band_style(
     palette: Union[str, List[str]] = None,
     nodata: Union[int, float] = None,
     scheme: str = None,
+    n_colors: int = 255,
 ):
     style = None
     if isinstance(band, (int, str)):
@@ -47,7 +48,7 @@ def make_single_band_style(
         if palette:
             if isinstance(palette, str):
                 try:
-                    style["palette"] = get_palette_by_name(palette)
+                    style["palette"] = get_palette_by_name(palette, n_colors=n_colors)
                 except ValueError as e:
                     # Safely catch bad color palettes to avoid server errors
                     logger.error(e)
@@ -75,6 +76,7 @@ def make_style(
     vmax: Union[Union[float, int], List[Union[float, int]]] = None,
     nodata: Union[Union[float, int], List[Union[float, int]]] = None,
     scheme: Union[str, List[str]] = None,
+    n_colors: int = 255,
 ):
     style = None
     # Handle when user sets min/max/etc. but forgot band. Default to 1
@@ -86,7 +88,13 @@ def make_style(
     if isinstance(band, (int, str)):
         # Handle viewing single band
         style = make_single_band_style(
-            band, vmin=vmin, vmax=vmax, palette=palette, nodata=nodata, scheme=scheme
+            band,
+            vmin=vmin,
+            vmax=vmax,
+            palette=palette,
+            nodata=nodata,
+            scheme=scheme,
+            n_colors=n_colors,
         )
     elif isinstance(band, Iterable):
         # Handle viewing multiple bands together

--- a/localtileserver/tileserver/templates/tileserver/_include/palettes.html
+++ b/localtileserver/tileserver/templates/tileserver/_include/palettes.html
@@ -19,11 +19,15 @@
     <option>linear</option>
     <option>discrete</option>
   </select>
+  <br />
+  <label for="nColors">Number of colors:</label>
+  <input id="nColors" type="number" step="1" onChange='changeColors();'>
 </div>
 <script>
   var colorsSubGroup = document.getElementById('colorsSubGroup');
   var colorsDropdown = document.getElementById('colors');
   var schemeDropdown = document.getElementById('scheme');
+  var nColors = document.getElementById('nColors');
   var bandDropdown = document.getElementById('bandChoice');
   var colorsMin = document.getElementById('mincolor');
   var colorsMax = document.getElementById('maxcolor');
@@ -37,6 +41,9 @@
   }
   if (windowSearchParams['scheme']) {
     schemeDropdown.value = windowSearchParams['scheme']
+  }
+  if (windowSearchParams['n_colors']) {
+    nColors.value = windowSearchParams['n_colors']
   }
 
   for (const [source, values] of Object.entries(bands)) {
@@ -78,6 +85,7 @@
     updateTileUrlOption('min', colorsMin.value);
     updateTileUrlOption('max', colorsMax.value);
     updateTileUrlOption('scheme', schemeDropdown.value)
+    updateTileUrlOption('n_colors', nColors.value)
     updateTileLayer();
   }
 
@@ -88,6 +96,7 @@
       updateTileUrlOption('min', undefined);
       updateTileUrlOption('max', undefined);
       updateTileUrlOption('scheme', undefined)
+      updateTileUrlOption('n_colors', undefined)
       colorsSubGroup.style.display = 'none';
       updateTileLayer();
     } else {

--- a/localtileserver/tileserver/templates/tileserver/_include/palettes.html
+++ b/localtileserver/tileserver/templates/tileserver/_include/palettes.html
@@ -21,7 +21,7 @@
   </select>
   <br />
   <label for="nColors">Number of colors:</label>
-  <input id="nColors" type="number" step="1" onChange='changeColors();'>
+  <input id="nColors" type="number" step="1" value="255" onChange='changeColors();'>
 </div>
 <script>
   var colorsSubGroup = document.getElementById('colorsSubGroup');

--- a/localtileserver/tileserver/templates/tileserver/_include/palettes.html
+++ b/localtileserver/tileserver/templates/tileserver/_include/palettes.html
@@ -13,10 +13,17 @@
   <br />
   <input id="mincolor" type="number" step="0.01" onChange='changeColors();'>
   <input id="maxcolor" type="number" step="0.01" onChange='changeColors();'>
+  <br />
+  <label for="scheme">Choose a colormap scheme:</label>
+  <select id="scheme" onChange='changeColors();'>
+    <option>linear</option>
+    <option>discrete</option>
+  </select>
 </div>
 <script>
   var colorsSubGroup = document.getElementById('colorsSubGroup');
   var colorsDropdown = document.getElementById('colors');
+  var schemeDropdown = document.getElementById('scheme');
   var bandDropdown = document.getElementById('bandChoice');
   var colorsMin = document.getElementById('mincolor');
   var colorsMax = document.getElementById('maxcolor');
@@ -27,6 +34,9 @@
   }
   if (windowSearchParams['max']) {
     colorsMax.value = windowSearchParams['max']
+  }
+  if (windowSearchParams['scheme']) {
+    schemeDropdown.value = windowSearchParams['scheme']
   }
 
   for (const [source, values] of Object.entries(bands)) {
@@ -67,6 +77,7 @@
     updateTileUrlOption('palette', cmap);
     updateTileUrlOption('min', colorsMin.value);
     updateTileUrlOption('max', colorsMax.value);
+    updateTileUrlOption('scheme', schemeDropdown.value)
     updateTileLayer();
   }
 
@@ -76,6 +87,7 @@
       updateTileUrlOption('band', undefined);
       updateTileUrlOption('min', undefined);
       updateTileUrlOption('max', undefined);
+      updateTileUrlOption('scheme', undefined)
       colorsSubGroup.style.display = 'none';
       updateTileLayer();
     } else {

--- a/localtileserver/tileserver/templates/tileserver/baseTileViewer.html
+++ b/localtileserver/tileserver/templates/tileserver/baseTileViewer.html
@@ -8,7 +8,7 @@
   function insertWindowUrlParam(key, value) {
     if (history.pushState) {
       let searchParams = new URLSearchParams(window.location.search);
-      if (value === undefined) {
+      if (value === undefined || value === '') {
         searchParams.delete(key);
       } else {
         searchParams.set(key, value);
@@ -24,7 +24,7 @@
     const url = new URL(tileUrl);
     const urlParams = new URLSearchParams(window.location.search);
     var searchParams = url.searchParams;
-    if (value === undefined) {
+    if (value === undefined || value === '') {
       searchParams.delete(option);
     } else {
       searchParams.set(option, value);

--- a/localtileserver/widgets.py
+++ b/localtileserver/widgets.py
@@ -19,6 +19,7 @@ def get_leaflet_tile_layer(
     vmin: Union[Union[float, int], List[Union[float, int]]] = None,
     vmax: Union[Union[float, int], List[Union[float, int]]] = None,
     nodata: Union[Union[float, int], List[Union[float, int]]] = None,
+    scheme: Union[str, List[str]] = None,
     attribution: str = None,
     **kwargs,
 ):
@@ -53,6 +54,13 @@ def get_leaflet_tile_layer(
         a single band.
     nodata : float
         The value from the band to use to interpret as not valid data.
+    scheme : str
+        This is either ``linear`` (the default) or ``discrete``. If a
+        palette is specified, ``linear`` uses a piecewise linear
+        interpolation, and ``discrete`` uses exact colors from the palette
+        with the range of the data mapped into the specified number of
+        colors (e.g., a palette with two colors will split exactly halfway
+        between the min and max values).
     attribution : str
         Attribution for the source raster. This
         defaults to a message about it being a local file.
@@ -84,6 +92,7 @@ def get_leaflet_tile_layer(
         vmin=vmin,
         vmax=vmax,
         nodata=nodata,
+        scheme=scheme,
     )
     if attribution is None:
         attribution = DEFAULT_ATTRIBUTION
@@ -190,6 +199,7 @@ def get_folium_tile_layer(
     vmin: Union[Union[float, int], List[Union[float, int]]] = None,
     vmax: Union[Union[float, int], List[Union[float, int]]] = None,
     nodata: Union[Union[float, int], List[Union[float, int]]] = None,
+    scheme: Union[str, List[str]] = None,
     attr: str = None,
     **kwargs,
 ):
@@ -224,6 +234,13 @@ def get_folium_tile_layer(
         a single band.
     nodata : float
         The value from the band to use to interpret as not valid data.
+    scheme : str
+        This is either ``linear`` (the default) or ``discrete``. If a
+        palette is specified, ``linear`` uses a piecewise linear
+        interpolation, and ``discrete`` uses exact colors from the palette
+        with the range of the data mapped into the specified number of
+        colors (e.g., a palette with two colors will split exactly halfway
+        between the min and max values).
     attr : str
         Folium requires the custom tile source have an attribution. This
         defaults to a message about it being a local file.
@@ -248,6 +265,7 @@ def get_folium_tile_layer(
         vmin=vmin,
         vmax=vmax,
         nodata=nodata,
+        scheme=scheme,
     )
     if attr is None:
         attr = DEFAULT_ATTRIBUTION

--- a/localtileserver/widgets.py
+++ b/localtileserver/widgets.py
@@ -20,6 +20,7 @@ def get_leaflet_tile_layer(
     vmax: Union[Union[float, int], List[Union[float, int]]] = None,
     nodata: Union[Union[float, int], List[Union[float, int]]] = None,
     scheme: Union[str, List[str]] = None,
+    n_colors: int = 255,
     attribution: str = None,
     **kwargs,
 ):
@@ -61,6 +62,9 @@ def get_leaflet_tile_layer(
         with the range of the data mapped into the specified number of
         colors (e.g., a palette with two colors will split exactly halfway
         between the min and max values).
+    n_colors : int
+        The number (positive integer) of colors to discretize the matplotlib
+        color palettes when used.
     attribution : str
         Attribution for the source raster. This
         defaults to a message about it being a local file.
@@ -93,6 +97,7 @@ def get_leaflet_tile_layer(
         vmax=vmax,
         nodata=nodata,
         scheme=scheme,
+        n_colors=n_colors,
     )
     if attribution is None:
         attribution = DEFAULT_ATTRIBUTION
@@ -200,6 +205,7 @@ def get_folium_tile_layer(
     vmax: Union[Union[float, int], List[Union[float, int]]] = None,
     nodata: Union[Union[float, int], List[Union[float, int]]] = None,
     scheme: Union[str, List[str]] = None,
+    n_colors: int = 255,
     attr: str = None,
     **kwargs,
 ):
@@ -241,6 +247,9 @@ def get_folium_tile_layer(
         with the range of the data mapped into the specified number of
         colors (e.g., a palette with two colors will split exactly halfway
         between the min and max values).
+    n_colors : int
+        The number (positive integer) of colors to discretize the matplotlib
+        color palettes when used.
     attr : str
         Folium requires the custom tile source have an attribution. This
         defaults to a message about it being a local file.
@@ -266,6 +275,7 @@ def get_folium_tile_layer(
         vmax=vmax,
         nodata=nodata,
         scheme=scheme,
+        n_colors=n_colors,
     )
     if attr is None:
         attr = DEFAULT_ATTRIBUTION

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,9 +3,9 @@ flask>=2.0.0
 Flask-Caching
 flask-restx>=0.5.0
 --find-links https://girder.github.io/large_image_wheels GDAL
-large-image[memcached]
-large-image-source-gdal
-large-image-source-pil
+large-image[memcached]>=1.10
+large-image-source-gdal>=1.10
+large-image-source-pil>=1.10
 requests
 scooby
 pytest

--- a/requirements_win.txt
+++ b/requirements_win.txt
@@ -1,9 +1,9 @@
 click
 flask>=2.0.0
 Flask-Caching
-large-image
-large-image-source-gdal
-large-image-source-pil
+large-image>=1.10
+large-image-source-gdal>=1.10
+large-image-source-pil>=1.10
 requests
 scooby
 pytest

--- a/setup.py
+++ b/setup.py
@@ -44,8 +44,8 @@ setup(
         "Flask-Caching",
         "flask-restx>=0.5.0",
         "GDAL",
-        "large_image",
-        "large_image_source_gdal",
+        "large-image>=1.10",
+        "large-image-source-gdal>=1.10",
         "requests",
         "scooby",
     ],
@@ -53,7 +53,7 @@ setup(
         "leaflet": ["ipyleaflet"],
         "folium": ["folium"],
         "colormaps": ["matplotlib", "colorcet", "cmocean"],
-        "sources": ["large-image-source-pil", "large-image-source-tiff"],
+        "sources": ["large-image-source-pil>=1.10", "large-image-source-tiff>=1.10"],
     },
     entry_points={
         "console_scripts": [


### PR DESCRIPTION
Utilize https://github.com/girder/large_image/issues/753 and https://github.com/girder/large_image/issues/755 - waiting on large_image's next release

This adds a new "discrete" option for the colormap/palette for categorical colors:

```py
from localtileserver import get_leaflet_tile_layer, TileClient
from ipyleaflet import Map, ScaleControl, FullScreenControl

# First, create a tile server from local raster file
tile_client = TileClient('/Users/bane/Desktop/B04.jp2')

# Create ipyleaflet tile layer from that server
t = get_leaflet_tile_layer(tile_client, band=1, palette=["#000", "#f00"], scheme="discrete")

# Create ipyleaflet, add layers, add draw control, display
m = Map(center=tile_client.center())

m.add_layer(t)
m.add_control(ScaleControl(position='bottomleft'))
m.add_control(FullScreenControl())
m
```

![Screen Shot 2022-01-14 at 9 32 17 AM](https://user-images.githubusercontent.com/22067021/149550910-f70de9a2-56cb-4acc-9a96-282e9cfcc81a.png)


