### PR TITLE
Pin werkzeug<2.1.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ pytest-cov
 matplotlib
 gunicorn
 cmocean
+werkzeug<2.1.0

--- a/requirements_win.txt
+++ b/requirements_win.txt
@@ -10,3 +10,4 @@ pytest
 pytest-cov
 folium
 matplotlib
+werkzeug<2.1.0

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ else:
     long_description = ""
 
 # major, minor, patch
-version_info = 0, 4, 4
+version_info = 0, 4, 5
 # Nice string for the version
 __version__ = ".".join(map(str, version_info))
 

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,7 @@ setup(
         "large-image-source-gdal>=1.10",
         "requests",
         "scooby",
+        "werkzeug<2.1.0",
     ],
     extras_require={
         "colormaps": ["matplotlib", "colorcet", "cmocean"],


### PR DESCRIPTION
Temporarily pins werkzeug under 2.1.0 while I figure out the server shutdown changes

Addresses #75

A patch release will come with this