### PR TITLE
Remove forking from TileClient

### DIFF
--- a/localtileserver/client.py
+++ b/localtileserver/client.py
@@ -306,10 +306,6 @@ class TileClient(BaseTileClient):
         to getting an available port.
     debug : bool
         Run the tile server in debug mode.
-    threaded : bool
-        Run the background server as a ThreadedWSGIServer. Default True.
-    processes : int
-        If processes is greater than 1, run background server as ForkingWSGIServer
     client_port : int
         The port on your client browser to use for fetching tiles. This is
         useful when running in Docker and performing port forwarding.
@@ -323,15 +319,13 @@ class TileClient(BaseTileClient):
         filename: Union[pathlib.Path, str],
         port: Union[int, str] = "default",
         debug: bool = False,
-        threaded: bool = True,
-        processes: int = 1,
         host: str = "127.0.0.1",
         client_port: int = None,
         client_host: str = None,
         client_prefix: str = None,
     ):
         super().__init__(filename)
-        self._key = launch_server(port, debug, threaded=threaded, processes=processes, host=host)
+        self._key = launch_server(port, debug, host=host)
         # Store actual port just in case
         self._port = ServerManager.get_server(self._key).srv.port
         client_host, client_port, client_prefix = get_default_client_params(
@@ -433,8 +427,6 @@ def get_or_create_tile_client(
     source: Union[pathlib.Path, str, TileClient],
     port: Union[int, str] = "default",
     debug: bool = False,
-    threaded: bool = True,
-    processes: int = 1,
 ):
     """A helper to safely get a TileClient from a path on disk.
 
@@ -450,7 +442,7 @@ def get_or_create_tile_client(
     _internally_created = False
     # Launch tile server if file path is given
     if not isinstance(source, TileClient):
-        source = TileClient(source, port=port, debug=debug, threaded=threaded, processes=processes)
+        source = TileClient(source, port=port, debug=debug)
         _internally_created = True
     # Check that the tile source is valid and no server errors
     try:

--- a/localtileserver/server.py
+++ b/localtileserver/server.py
@@ -102,8 +102,6 @@ class TileServerThread(threading.Thread):
         self.ctx = app.app_context()
         self.ctx.push()
 
-        if self.srv.multithread:
-            self.srv.block_on_close = False
         # daemon = True  # CRITICAL for safe exit
         threading.Thread.__init__(self, daemon=True, target=self.srv.serve_forever)
         self._lts_initialized = True
@@ -113,10 +111,8 @@ class TileServerThread(threading.Thread):
 
     def shutdown(self):
         if self._lts_initialized and self.is_alive():
-            if self.srv.multithread:
-                self.srv.shutdown()
-            else:
-                self.srv.server_close()
+            self.srv.shutdown()
+            self.srv.server_close()
             self.join()
 
     def __del__(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,3 @@ pytest-cov
 matplotlib
 gunicorn
 cmocean
-werkzeug<2.1.0

--- a/requirements_win.txt
+++ b/requirements_win.txt
@@ -10,4 +10,3 @@ pytest
 pytest-cov
 folium
 matplotlib
-werkzeug<2.1.0

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,6 @@ setup(
         "large-image-source-gdal>=1.10",
         "requests",
         "scooby",
-        "werkzeug<2.1.0",
     ],
     extras_require={
         "colormaps": ["matplotlib", "colorcet", "cmocean"],

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -29,10 +29,9 @@ def get_content(url):
     return r.content
 
 
-@pytest.mark.parametrize("processes", [1, 5])
-def test_create_tile_client(bahamas_file, processes):
+def test_create_tile_client(bahamas_file):
     assert ServerManager.server_count() == 0
-    tile_client = TileClient(bahamas_file, processes=processes, debug=True)
+    tile_client = TileClient(bahamas_file, debug=True)
     assert tile_client.filename == bahamas_file
     assert tile_client.server_port
     assert tile_client.server_base_url


### PR DESCRIPTION
This removes the ability to use forking with the `TileClient` (removing the `threaded` and `processes` arguments) in order to support werkzeug>=2.1.0

There is no way to programmatically shut down a werkzeug server that is launched in forking mode, only a multithreaded server.

This should have almost no impact on users and frankly, this makes the API a little bit cleaner and more uniform across Mac, Linux, and Windows

related: https://github.com/pallets/werkzeug/issues/2363

Closes #75 