### PR TITLE
fix documentation color to light mode

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -70,6 +70,7 @@ html_context = {
 }
 
 html_theme_options = {
+    "default_mode": "light",
     "google_analytics_id": "G-14GFZDPSQG",
     "show_prev_next": False,
     "github_url": "https://github.com/banesullivan/localtileserver",
@@ -90,6 +91,7 @@ html_theme_options = {
             "icon": "fa fa-user fa-fw",
         },
     ],
+    "navbar_end": ["navbar-icon-links"],
 }
 
 html_sidebars = {

--- a/requirements_doc.txt
+++ b/requirements_doc.txt
@@ -1,6 +1,6 @@
 sphinx
 sphinx-copybutton
 sphinx-notfound-page
-pydata-sphinx-theme
+pydata-sphinx-theme==0.9
 jupyter-sphinx
 bokeh


### PR DESCRIPTION
In the recent dev of `pydata-sphinx-theme` I added a theme switcher, unfortunately, the `jupyter-sphinx` extension is not (yet) responsive to this switch making it ... ugly. In this PR, I changed the default behavior and force the doc to always display itself in light theme.

I was wondering any reason why you are not using ReadTheDoc to build your documentation ? 