### PR TITLE
Fix projection issues when extractiong ROI

### DIFF
--- a/localtileserver/tileserver/rest.py
+++ b/localtileserver/tileserver/rest.py
@@ -376,7 +376,7 @@ class RegionWorldView(BaseRegionView):
     """
 
     def get(self):
-        tile_source = self.get_tile_source()
+        tile_source = self.get_tile_source(projection="EPSG:3857")
         if not isinstance(tile_source, GDALFileTileSource):
             raise BadRequest("Source image must have geospatial reference.")
         units = request.args.get("units", "EPSG:4326")


### PR DESCRIPTION
Resolves #124, cc @giswqs

```py
from ipyleaflet import Map, projections, Rectangle
from localtileserver import examples
from localtileserver import TileClient, get_leaflet_tile_layer

rectangle = Rectangle(bounds=((23.8959, -77.9425, 23.8959), (24.2019, -77.4701)), 
                      color='red',
                      fill=False,
                      weight=1,
                      )

client = examples.get_bahamas()

t = get_leaflet_tile_layer(client)


m = Map(center=client.center(), zoom=client.default_zoom)
m.add_layer(t)
m.add_layer(rectangle)
m
```
<img width="1114" alt="Screen Shot 2022-11-02 at 11 09 39 AM" src="https://user-images.githubusercontent.com/22067021/199555709-ada38b45-e6da-448f-84b5-67425e69b0e3.png">


```py
path = client.extract_roi(-77.9425, -77.4701, 23.8959, 24.2019, units='EPSG:4326', return_path=True, )

roi = TileClient(path)

m = Map(center=roi.center(), zoom=roi.default_zoom, crs=projections.EPSG3857)
m.add_layer(get_leaflet_tile_layer(roi, max_zoom=22, max_natvie_zoom=22, default_projection='EPSG:4326'))
m.add_layer(rectangle)
m
```
<img width="1116" alt="Screen Shot 2022-11-02 at 11 09 52 AM" src="https://user-images.githubusercontent.com/22067021/199555664-65411b84-7fbb-4454-877a-0a533303dad0.png">

<img width="372" alt="Screen Shot 2022-11-02 at 11 05 51 AM" src="https://user-images.githubusercontent.com/22067021/199555680-b7ae3e1a-d6ab-440b-9904-694efd969842.png">


