### PR TITLE
pin pyproj==3.3.1.1

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -19,10 +19,10 @@ jobs:
         with:
           python-version: 3.9
       # Handle GDAL
-      - name: Install GDAL
+      - name: Install GDAL and PyProj
         run: |
           python -m pip install --upgrade pip
-          pip install --find-links=https://girder.github.io/large_image_wheels --no-cache GDAL
+          pip install --find-links=https://girder.github.io/large_image_wheels --no-cache GDAL pyproj==3.3.1.1
       - name: Test GDAL installation
         run: |
           python -c "from osgeo import gdal"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,10 +22,10 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       # Handle GDAL
-      - name: Install GDAL
+      - name: Install GDAL and PyProj
         run: |
           python -m pip install --upgrade pip
-          pip install --find-links=https://girder.github.io/large_image_wheels --no-cache GDAL
+          pip install --find-links=https://girder.github.io/large_image_wheels --no-cache GDAL pyproj==3.3.1.1
       - name: Test GDAL installation
         run: |
           python -c "from osgeo import gdal"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.7, 3.8, 3.9, "3.10"]
+        python-version: [3.8, 3.9, "3.10"]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,4 +15,3 @@ matplotlib
 gunicorn
 cmocean
 werkzeug<2.2
---find-links https://girder.github.io/large_image_wheels pyproj==3.3.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ matplotlib
 gunicorn
 cmocean
 werkzeug<2.2
+importlib-metadata==4.13.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ Flask-Caching
 flask-cors
 flask-restx>=0.5.0
 sentry-sdk[flask]
---find-links https://girder.github.io/large_image_wheels GDAL pyproj==3.3.1.1
+--find-links https://girder.github.io/large_image_wheels GDAL
 large-image[memcached,gdal,pil]>=1.14.1
 requests
 server-thread
@@ -15,3 +15,4 @@ matplotlib
 gunicorn
 cmocean
 werkzeug<2.2
+--find-links https://girder.github.io/large_image_wheels pyproj==3.3.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,4 +15,4 @@ matplotlib
 gunicorn
 cmocean
 werkzeug<2.2
-importlib-metadata==4.13.0
+pyproj==3.3.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ Flask-Caching
 flask-cors
 flask-restx>=0.5.0
 sentry-sdk[flask]
---find-links https://girder.github.io/large_image_wheels GDAL
+--find-links https://girder.github.io/large_image_wheels GDAL pyproj==3.3.1.1
 large-image[memcached,gdal,pil]>=1.14.1
 requests
 server-thread
@@ -15,4 +15,3 @@ matplotlib
 gunicorn
 cmocean
 werkzeug<2.2
---find-links https://girder.github.io/large_image_wheels pyproj==3.3.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,4 +15,4 @@ matplotlib
 gunicorn
 cmocean
 werkzeug<2.2
-pyproj==3.3.1.1
+--find-links https://girder.github.io/large_image_wheels pyproj==3.3.1.1

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python",
     ],
     python_requires=">=3.7",

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ else:
     long_description = ""
 
 # major, minor, patch
-version_info = 0, 6, 0
+version_info = 0, 6, 1
 # Nice string for the version
 __version__ = ".".join(map(str, version_info))
 


### PR DESCRIPTION
Works around an issue with the large-image pyproj wheel:

```
File /opt/hostedtoolcache/Python/3.9.15/x64/lib/python3.9/site-packages/large_image_source_gdal/__init__.py:35
     27 from osgeo import gdal, gdal_array, gdalconst, osr
     29 # isort: off
     30 
     31 # pyproj stopped supporting older pythons, so on those versions its database is
     32 # aging; as such, if on those older versions of python if it is imported before
     33 # gdal, there can be a database version conflict; importing after gdal avoids
     34 # this.
---> 35 import pyproj
     37 # isort: on
     39 import large_image

File /opt/hostedtoolcache/Python/3.9.15/x64/lib/python3.9/site-packages/pyproj/__init__.py:74
     66 from pyproj.proj import Proj, pj_list  # noqa: F401 pylint: disable=unused-import
     67 from pyproj.transformer import (  # noqa: F401 pylint: disable=unused-import
     68     Transformer,
     69     itransform,
     70     proj_version_str,
     71     transform,
     72 )
---> 74 __version__ = importlib.metadata.version(__package__)
     75 __all__ = [
     76     "Proj",
     77     "Geod",
   (...)
     88     "show_versions",
     89 ]
     90 __proj_version__ = proj_version_str

AttributeError: module 'importlib' has no attribute 'metadata'
```