### PR TITLE
Free werkzeug

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,4 +14,4 @@ pytest-cov
 matplotlib
 gunicorn
 cmocean
-werkzeug<2.2
+werkzeug

--- a/requirements_win.txt
+++ b/requirements_win.txt
@@ -10,4 +10,4 @@ pytest
 pytest-cov
 folium
 matplotlib
-werkzeug<2.2
+werkzeug

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(
         "requests",
         "server-thread",
         "scooby",
-        "werkzeug<2.2",
+        "werkzeug",
     ],
     extras_require={
         "colormaps": ["matplotlib", "colorcet", "cmocean"],


### PR DESCRIPTION
Close #113

Frees the `werkzeug` dependency after #76 now that https://github.com/python-restx/flask-restx/issues/460 is fixed