### PR TITLE
Limit flask and bug fixes

### DIFF
--- a/localtileserver/client.py
+++ b/localtileserver/client.py
@@ -410,10 +410,6 @@ class BaseTileClientInterface:
         """
         raise NotImplementedError  # pragma: no cover
 
-    def histogram(self, bins: int = 256, density: bool = False):
-        """Get a histoogram for each band."""
-        raise NotImplementedError  # pragma: no cover
-
     @property
     def default_zoom(self):
         m = self.metadata_safe()
@@ -671,10 +667,6 @@ class LocalTileClient(BaseTileClientInterface):
         region = {"left": x, "top": y, "units": units}
         return self.tile_source.getPixel(region=region)
 
-    def histogram(self, bins: int = 256, density: bool = False):
-        result = self.tile_source.histogram(bins=bins, density=density)
-        return result["histogram"]
-
 
 class BaseRestfulTileClient(BaseTileClientInterface):
     """Connect to a localtileserver instance.
@@ -771,15 +763,6 @@ class BaseRestfulTileClient(BaseTileClientInterface):
         if projection:
             params["projection"] = projection
         url = add_query_parameters(self.create_url("api/pixel"), params)
-        r = requests.get(url)
-        r.raise_for_status()
-        return r.json()
-
-    def histogram(self, bins: int = 256, density: bool = False):
-        params = {}
-        params["density"] = density
-        params["bins"] = bins
-        url = add_query_parameters(self.create_url("api/histogram"), params)
         r = requests.get(url)
         r.raise_for_status()
         return r.json()

--- a/localtileserver/client.py
+++ b/localtileserver/client.py
@@ -691,51 +691,6 @@ class BaseRestfulTileClient(BaseTileClientInterface):
             return save_file_from_request(r, output_path)
         return ImageBytes(r.content, mimetype=r.headers["Content-Type"])
 
-    def extract_roi(
-        self,
-        left: float,
-        right: float,
-        bottom: float,
-        top: float,
-        units: str = "EPSG:4326",
-        encoding: str = "TILED",
-        output_path: pathlib.Path = None,
-        return_bytes: bool = False,
-        return_path: bool = False,
-    ):
-        path = f"api/world/region.tif?units={units}&encoding={encoding}&left={left}&right={right}&bottom={bottom}&top={top}"
-        r = requests.get(self.create_url(path))
-        r.raise_for_status()
-        if return_bytes:
-            return ImageBytes(r.content, mimetype=r.headers["Content-Type"])
-        output_path = save_file_from_request(r, output_path)
-        if return_path:
-            return output_path
-        return TileClient(output_path)
-
-    def extract_roi_pixel(
-        self,
-        left: int,
-        right: int,
-        bottom: int,
-        top: int,
-        encoding: str = "TILED",
-        output_path: pathlib.Path = None,
-        return_bytes: bool = False,
-        return_path: bool = False,
-    ):
-        path = f"/api/pixel/region.tif?encoding={encoding}&left={left}&right={right}&bottom={bottom}&top={top}"
-        r = requests.get(self.create_url(path))
-        r.raise_for_status()
-        if return_bytes:
-            return ImageBytes(r.content, mimetype=r.headers["Content-Type"])
-        output_path = save_file_from_request(r, output_path)
-        if return_path:
-            return output_path
-        return TileClient(
-            output_path, default_projection="EPSG:3857" if encoding == "TILED" else None
-        )
-
     def metadata(self, projection: Optional[str] = ""):
         if projection not in self._metadata:
             if projection == "":

--- a/localtileserver/tiler/utilities.py
+++ b/localtileserver/tiler/utilities.py
@@ -8,6 +8,7 @@ from urllib.parse import urlencode, urlparse
 
 import large_image
 from large_image_source_rasterio import RasterioFileTileSource
+from rasterio import CRS
 
 from localtileserver.tiler.data import clean_url, get_data_path, get_pine_gulch_url
 
@@ -139,6 +140,8 @@ def get_meta_data(tile_source: RasterioFileTileSource):
     meta.update(tile_source.getInternalMetadata())
     # Override bounds for EPSG:4326
     meta["bounds"] = get_tile_bounds(tile_source)
+    if isinstance(meta["projection"], CRS):
+        meta["projection"] = meta["projection"].to_string()
     return meta
 
 

--- a/localtileserver/web/rest.py
+++ b/localtileserver/web/rest.py
@@ -497,36 +497,3 @@ class PixelView(BasePixelOperation):
         pixel.pop("value", None)
         pixel.update(region)
         return pixel
-
-
-@api.doc(
-    params={
-        "bins": {
-            "type": "int",
-            "default": 256,
-        },
-        "density": {
-            "type": "bool",
-            "default": False,
-        },
-    }
-)
-class HistogramView(BasePixelOperation):
-    """Returns histogram."""
-
-    def get(self):
-        kwargs = dict(
-            bins=int(request.args.get("bins", 256)),
-            density=str_to_bool(request.args.get("density", "False")),
-        )
-        tile_source = self.get_tile_source(projection=None)
-        result = tile_source.histogram(**kwargs)
-        result = result["histogram"]
-        for entry in result:
-            for key in {"bin_edges", "hist", "range"}:
-                if key in entry:
-                    entry[key] = [float(val) for val in list(entry[key])]
-            for key in {"min", "max", "samples"}:
-                if key in entry:
-                    entry[key] = float(entry[key])
-        return result

--- a/localtileserver/web/urls.py
+++ b/localtileserver/web/urls.py
@@ -54,11 +54,6 @@ rest.api.add_resource(
     endpoint="pixel",
 )
 rest.api.add_resource(
-    rest.HistogramView,
-    "/histogram",
-    endpoint="histogram",
-)
-rest.api.add_resource(
     rest.ListTileSources,
     "/sources",
     endpoint="sources",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 click
-flask>=2.0.0
+flask>=2.0.0,<3
 Flask-Caching
 flask-cors
 flask-restx>=0.5.0

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ else:
     long_description = ""
 
 # major, minor, patch
-version_info = 0, 7, 1
+version_info = 0, 7, 2
 # Nice string for the version
 __version__ = ".".join(map(str, version_info))
 
@@ -42,7 +42,7 @@ setup(
     python_requires=">=3.7",
     install_requires=[
         "click",
-        "flask>=2.0.0",
+        "flask>=2.0.0,<3",
         "Flask-Caching",
         "flask-cors",
         "flask-restx>=0.5.0",

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -228,12 +228,6 @@ def test_pixel(bahamas):
     assert "bands" in pix
 
 
-@pytest.mark.skip
-def test_histogram(bahamas):
-    hist = bahamas.histogram()
-    assert len(hist)
-
-
 @pytest.mark.parametrize("encoding", ["PNG", "JPEG", "JPG"])
 def test_thumbnail_encodings(bahamas, encoding):
     # large-image's rasterio source cannot handle: "TIF", "TIFF"

--- a/tests/test_client_rest.py
+++ b/tests/test_client_rest.py
@@ -158,13 +158,6 @@ def test_pixel(bahamas_file):
     assert "bands" in pix
 
 
-@pytest.mark.skip
-def test_histogram(bahamas_file):
-    bahamas = RestTileClient(bahamas_file)
-    hist = bahamas.histogram()
-    assert len(hist)
-
-
 @pytest.mark.parametrize("encoding", ["PNG", "JPEG", "JPG"])
 def test_thumbnail_encodings(bahamas_file, encoding):
     bahamas = RestTileClient(bahamas_file)


### PR DESCRIPTION
Limit's `flask<3` until flask_restx's https://github.com/python-restx/flask-restx/issues/566 is handled.

Resolves #177

Also:

- Fixes an issue from large-image where the rasterio source is passing a CRS object to `getMetdata()` which isn't JSON serializable
- Drops support for extracting ROIs with the REST client as this has been broken and isn't a "rest-ful" operation.
- Drops support for histograms as it has been broken and not tested for a while

cc @dfguerrerom