### PR TITLE
Revert "fixed get_cmap dependency"

### DIFF
--- a/localtileserver/tiler/palettes.py
+++ b/localtileserver/tiler/palettes.py
@@ -17,7 +17,7 @@ def is_mpl_cmap(name: str):
     try:
         import matplotlib
 
-        matplotlib.cm.get_cmap(name)
+        matplotlib.colormaps.get_cmap(name)
         return True
     except ImportError:  # pragma: no cover
         logger.error("Install matplotlib for additional colormap choices.")


### PR DESCRIPTION
Reverts banesullivan/localtileserver#167

This was wrong

```
MatplotlibDeprecationWarning: The get_cmap function was deprecated in Matplotlib 3.7 and will be removed two minor releases later. Use ``matplotlib.colormaps[name]`` or ``matplotlib.colormaps.get_cmap(obj)`` instead.
    matplotlib.cm.get_cmap(name)
```