### PR TITLE
Constrain bounds of folium tile layer

### DIFF
--- a/localtileserver/widgets.py
+++ b/localtileserver/widgets.py
@@ -176,7 +176,6 @@ def get_folium_tile_layer(
     # Safely import folium
     try:
         from folium import TileLayer
-        from traitlets import Tuple, Union
     except ImportError as e:  # pragma: no cover
         raise ImportError(f"Please install `folium`: {e}")
 
@@ -197,7 +196,7 @@ def get_folium_tile_layer(
         )
 
     class FoliumTileLayer(TileLayer, LocalTileServerLayerMixin):
-        bounds = Union((Tuple(),), default_value=None, allow_none=True).tag(sync=True, o=True)
+        pass
 
     source, created = get_or_create_tile_client(
         source,

--- a/localtileserver/widgets.py
+++ b/localtileserver/widgets.py
@@ -14,7 +14,8 @@ DEFAULT_ATTRIBUTION = "Raster file served by <a href='https://github.com/banesul
 class LocalTileServerLayerMixin:
     """Mixin class for tile layers using localtileserver."""
 
-    pass
+    # Prevent the client from being garbage collected
+    tile_server: TileClient
 
 
 def get_leaflet_tile_layer(

--- a/localtileserver/widgets.py
+++ b/localtileserver/widgets.py
@@ -14,8 +14,7 @@ DEFAULT_ATTRIBUTION = "Raster file served by <a href='https://github.com/banesul
 class LocalTileServerLayerMixin:
     """Mixin class for tile layers using localtileserver."""
 
-    # Prevent the client from being garbage collected
-    tile_server: TileClient
+    pass
 
 
 def get_leaflet_tile_layer(
@@ -176,6 +175,7 @@ def get_folium_tile_layer(
     # Safely import folium
     try:
         from folium import TileLayer
+        from traitlets import Tuple, Union
     except ImportError as e:  # pragma: no cover
         raise ImportError(f"Please install `folium`: {e}")
 
@@ -196,7 +196,7 @@ def get_folium_tile_layer(
         )
 
     class FoliumTileLayer(TileLayer, LocalTileServerLayerMixin):
-        pass
+        bounds = Union((Tuple(),), default_value=None, allow_none=True).tag(sync=True, o=True)
 
     source, created = get_or_create_tile_client(
         source,
@@ -213,7 +213,9 @@ def get_folium_tile_layer(
     )
     if attr is None:
         attr = DEFAULT_ATTRIBUTION
-    tile_layer = FoliumTileLayer(tiles=url, attr=attr, **kwargs)
+    b = source.bounds()
+    bounds = ((b[0], b[2]), (b[1], b[3]))
+    tile_layer = FoliumTileLayer(tiles=url, bounds=bounds, attr=attr, **kwargs)
     if created:
         # HACK: Prevent the client from being garbage collected
         tile_layer.tile_server = source


### PR DESCRIPTION
Fixes an issue where when users are using folium map and explore outside of the bounds of the raster the localtileserver is continuously queried resulting in excessive 404 errors. The get_folium_tile_layer() function is now similar to the get_leaflet_tile_layer() function which has solved the issue.