### PR TITLE
Replace `anywidget-command` kind

### DIFF
--- a/localtileserver/custom/lts_widget.js
+++ b/localtileserver/custom/lts_widget.js
@@ -38,7 +38,7 @@ function render({ model, el, experimental }) {
             tileHandlers[id] = handleTile;
 
             model.send(
-                { id, kind: "anywidget-command", name: "get_tile", msg: {...coords, identifier} },
+                { id, kind: "get_tile", msg: {...coords, identifier} },
                 undefined,
                 [],
             );


### PR DESCRIPTION
Replaces the `kind=anywidget-command` with just `kind=get_tile`. The `anywidget-command` stuff is an internal implementation detail for the `anywidget.experimental` features. `kind` is just a convention so that on the python side you can delegate to different methods in the `handle_custom_message` callback.