### PR TITLE
Fix minzoom and maxzoom attribute error

### DIFF
--- a/localtileserver/client.py
+++ b/localtileserver/client.py
@@ -89,14 +89,14 @@ class TilerInterface:
 
     @property
     def min_zoom(self):
-        if hasattr(self, "info") and hasattr(self.info, "minzoom"):
+        if hasattr(self.info, "minzoom"):
             return self.info.minzoom
         else:
             return self.reader.minzoom
 
     @property
     def max_zoom(self):
-        if hasattr(self, "info") and hasattr(self.info, "maxzoom"):
+        if hasattr(self.info, "maxzoom"):
             return self.info.maxzoom
         else:
             return self.reader.maxzoom

--- a/localtileserver/client.py
+++ b/localtileserver/client.py
@@ -89,11 +89,17 @@ class TilerInterface:
 
     @property
     def min_zoom(self):
-        return self.info.minzoom
+        if hasattr(self, "info"):
+            return self.info.minzoom
+        else:
+            return self.reader.minzoom
 
     @property
     def max_zoom(self):
-        return self.info.maxzoom
+        if hasattr(self, "info"):
+            return self.info.maxzoom
+        else:
+            return self.reader.maxzoom
 
     @property
     def default_zoom(self):

--- a/localtileserver/client.py
+++ b/localtileserver/client.py
@@ -89,14 +89,14 @@ class TilerInterface:
 
     @property
     def min_zoom(self):
-        if hasattr(self, "info"):
+        if hasattr(self, "info") and hasattr(self.info, "minzoom"):
             return self.info.minzoom
         else:
             return self.reader.minzoom
 
     @property
     def max_zoom(self):
-        if hasattr(self, "info"):
+        if hasattr(self, "info") and hasattr(self.info, "maxzoom"):
             return self.info.maxzoom
         else:
             return self.reader.maxzoom


### PR DESCRIPTION
rio-tiler v0.7.0.1 has removed min/max zoom attribute in the Info response. 
Fix #225 