### PR TITLE
Validate colormaps with rio-tiler

### DIFF
--- a/localtileserver/tiler/palettes.py
+++ b/localtileserver/tiler/palettes.py
@@ -1,43 +1,20 @@
 import logging
 
-try:
-    import cmocean  # noqa
-except ImportError:
-    pass
-try:
-    import colorcet  # noqa
-except ImportError:
-    pass
+from rio_tiler.colormap import cmap as RIO_CMAPS
 
 logger = logging.getLogger(__name__)
 
 
-def is_mpl_cmap(name: str):
-    """This will silently fail if matplotlib is not installed."""
-    try:
-        import matplotlib
-
-        matplotlib.colormaps.get_cmap(name)
-        return True
-    except ImportError:  # pragma: no cover
-        logger.error("Install matplotlib for additional colormap choices.")
-    except ValueError:
-        pass
-    return False
+def is_rio_cmap(name: str):
+    """Check whether cmap is supported by rio-tiler."""
+    return name in RIO_CMAPS.data.keys()
 
 
 def palette_valid_or_raise(name: str):
-    if not is_mpl_cmap(name):
-        raise ValueError(f"Please use a valid matplotlib colormap name. Invalid: {name}")
+    if not is_rio_cmap(name):
+        raise ValueError(f"Please use a valid rio-tiler registered colormap name. Invalid: {name}")
 
 
 def get_palettes():
     """List of available palettes."""
-    cmaps = {}
-    try:
-        import matplotlib.pyplot
-
-        cmaps["matplotlib"] = list(matplotlib.pyplot.colormaps())
-    except ImportError:  # pragma: no cover
-        logger.error("Install matplotlib for additional colormap choices.")
-    return cmaps
+    return {"matplotlib": list(RIO_CMAPS.data.keys())}

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -1,7 +1,7 @@
 import pytest
 
 from localtileserver import Report, TileClient
-from localtileserver.tiler.palettes import get_palettes, is_mpl_cmap
+from localtileserver.tiler.palettes import get_palettes, is_rio_cmap
 from localtileserver.validate import validate_cog
 
 has_mpl = False
@@ -14,14 +14,14 @@ except ImportError:
 
 
 def test_is_valid_palette_name():
-    assert is_mpl_cmap("viridis")
-    assert not is_mpl_cmap("foobar")
+    assert is_rio_cmap("viridis")
+    assert not is_rio_cmap("foobar")
 
 
 @pytest.mark.skipif(not has_mpl, reason="matplotlib not installed.")
 def test_mpl_colormaps():
-    assert is_mpl_cmap("viridis")
-    assert is_mpl_cmap("jet")
+    assert is_rio_cmap("viridis")
+    assert is_rio_cmap("jet")
 
 
 def test_report():


### PR DESCRIPTION
Resolves #235 by validating colormap names against rio-tiler's supported colormaps